### PR TITLE
Ajout d'un espace avant "habitant"

### DIFF
--- a/exercice 21/Program.cs
+++ b/exercice 21/Program.cs
@@ -16,7 +16,7 @@ namespace exercice_21
             string habitant = (Console.ReadLine());
             // affichage du nom de la ville et du nombre d'habitants
 
-            Console.Write(ville + " possède"+habitant+ "habitants.");
+            Console.Write(ville + " possède"+ habitant+ "habitants.");
             Console.ReadLine();
 
 


### PR DESCRIPTION
J'ai ajouter un espace avant "habitant" afin de rendre le corriger le code légerement;